### PR TITLE
[WIP] Set joint limits

### DIFF
--- a/robots/ada.urdf
+++ b/robots/ada.urdf
@@ -88,7 +88,7 @@
     <parent link="j2n6s200_link_base"/>
     <child link="j2n6s200_link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1"/>
+    <limit effort="2000" lower="-3.141592" upper="3.141592" velocity="1"/>
     <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -131,7 +131,7 @@
     <parent link="j2n6s200_link_1"/>
     <child link="j2n6s200_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="1"/>
+    <limit effort="2000" lower="-3.8451785" upper="0.7035858" velocity="1"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -174,7 +174,7 @@
     <parent link="j2n6s200_link_2"/>
     <child link="j2n6s200_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="1"/>
+    <limit effort="2000" lower="-4.104090" upper="0.9515727493" velocity="1"/>
     <origin rpy="0 3.14159265359 0" xyz="0 -0.410 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -217,7 +217,7 @@
     <parent link="j2n6s200_link_3"/>
     <child link="j2n6s200_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1"/>
+    <limit effort="2000" lower="-3.141592" upper="3.141592" velocity="1"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -260,7 +260,7 @@
     <parent link="j2n6s200_link_4"/>
     <child link="j2n6s200_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1"/>
+    <limit effort="2000" lower="-3.141592" upper="3.141592" velocity="1"/>
     <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -303,7 +303,7 @@
     <parent link="j2n6s200_link_5"/>
     <child link="j2n6s200_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1"/>
+    <limit effort="2000" lower="-3.141592" upper="3.141592" velocity="1"/>
     <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>


### PR DESCRIPTION
This constrains joint values of JACO for better planning, but this may be too limiting. Some of the DOF values are taken from old ADA. We will have to tune the limits. 