### PR TITLE
Bugfix/joint limits

### DIFF
--- a/robots/ada_with_camera_forque.srdf
+++ b/robots/ada_with_camera_forque.srdf
@@ -14,11 +14,6 @@
   <disable_collisions link1="j2n6s200_link_5" link2="j2n6s200_link_6"/>
   <disable_collisions link1="j2n6s200_link_6" link2="j2n6s200_end_effector"/>
   <disable_collisions link1="j2n6s200_link_6" link2="j2n6s200_joule"/>
-  <disable_collisions link1="j2n6s200_hand_base" link2="j2n6s200_joule"/>
-  <disable_collisions link1="j2n6s200_link_6" link2="j2n6s200_hand_base"/>
-  <disable_collisions link1="j2n6s200_link_6" link2="j2n6s200_link_finger_1"/>
-  <disable_collisions link1="j2n6s200_link_6" link2="j2n6s200_link_finger_2"/>
-  <disable_collisions link1="j2n6s200_end_effector" link2="j2n6s200_hand_base"/>
 
   <group name="j2n6s200_hand">
 	  <link name="j2n6s200_forque"/>

--- a/robots/ada_with_camera_forque.urdf
+++ b/robots/ada_with_camera_forque.urdf
@@ -18,7 +18,6 @@
    finger_proximal		57
    finger_distal      58
 -->
-  <link name="world"/>
   <link name="j2n6s200_link_base">
     <visual>
       <geometry>
@@ -39,11 +38,6 @@
       <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.000374272"/>
     </inertial>
   </link>
-  <joint name="j2n6s200_joint_base" type="fixed">
-    <parent link="world"/>
-    <child link="j2n6s200_link_base"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-  </joint>
   <link name="j2n6s200_link_1">
     <visual>
       <geometry>
@@ -303,6 +297,16 @@
     </actuator>
   </transmission>
   <link name="j2n6s200_end_effector">
+    <visual>
+      <geometry>
+        <box size="0.0001 0.0001 0.0001"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.01 0.01 0.01"/>
+      </geometry>
+    </collision>
   </link>
   <joint name="j2n6s200_joint_end_effector" type="fixed">
     <parent link="j2n6s200_link_6"/>
@@ -310,15 +314,6 @@
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
     <origin rpy="3.14159265359 0 0" xyz="0 0 -0.1600"/>
-  </joint>
-  <link name="j2n6s200_hand_base">
-   <!-- This is a fake link for defining the root of the hand -->
-  </link>
-  <joint name="j2n6s200_joint_hand_base" type="fixed">
-    <parent link="j2n6s200_link_6"/>
-    <child link="j2n6s200_hand_base"/>
-    <axis xyz="0 0 0"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
   </joint>
   <link name="j2n6s200_link_finger_1">
     <visual>
@@ -341,7 +336,7 @@
     </inertial>
   </link>
   <joint name="j2n6s200_joint_finger_1" type="revolute">
-    <parent link="j2n6s200_hand_base"/>
+    <parent link="j2n6s200_link_6"/>
     <child link="j2n6s200_link_finger_1"/>
     <axis xyz="0 0 1"/>
    <origin rpy="-1.570796327 1.75 1.57079632679490" xyz="-0.0025 0.03095 -0.11482"/>
@@ -383,7 +378,7 @@
     <child link="j2n6s200_link_finger_tip_1"/>
     <axis xyz="0 0 1"/>
     <origin rpy="0 0 0" xyz="0.044 -0.003 0"/>
-    <limit effort="0" lower="0" upper="2" velocity="1"/>
+    <limit effort="2000" lower="0" upper="2" velocity="1"/>
   </joint>
   <link name="j2n6s200_link_finger_2">
     <visual>
@@ -406,11 +401,11 @@
     </inertial>
   </link>
   <joint name="j2n6s200_joint_finger_2" type="revolute">
-    <parent link="j2n6s200_hand_base"/>
+    <parent link="j2n6s200_link_6"/>
     <child link="j2n6s200_link_finger_2"/>
     <axis xyz="0 0 1"/>
     <origin rpy="-1.570796327 1.75 -1.57079632679490" xyz="-0.0025 -0.03095 -0.11482"/>
-    <limit effort="0" lower="0" upper="2" velocity="1"/>
+    <limit effort="2000" lower="0" upper="2" velocity="1"/>
   </joint>
   <transmission name="j2n6s200_joint_finger_2_trans">
     <type>transmission_interface/SimpleTransmission</type>
@@ -508,6 +503,11 @@
   </joint>
 
   <link name="j2n6s200_forque_end_effector">
+    <visual>
+      <geometry>
+        <box size="0.0001 0.0001 0.0001"/>
+      </geometry>
+    </visual>
   </link>
   <joint name="j2n6s200_joint_forque_end_effector" type="fixed">
     <parent link="j2n6s200_forque"/>


### PR DESCRIPTION
This PR sets the joints limits of joint 2 and 3 to match the spec (software position limits)

http://www.kinovarobotics.com/wp-content/uploads/2015/02/JACO%C2%B2-6DOF-Advanced-Specification-Guide.pdf

And it reverts the modification of joint_tip_1 and joint_tip_2 from `revolute` to `fixed`. These cannot be revolute for real-robot, they should be handled as mimic joints, which will be addressed in another PR.
