### PR TITLE
Velocity limits too low

### DIFF
--- a/robots_urdf/ada_with_camera_forque.urdf
+++ b/robots_urdf/ada_with_camera_forque.urdf
@@ -57,7 +57,7 @@
     <parent link="world"/>
     <child link="j2n6s200_link_base"/>
     <axis xyz="0 0 0"/>
-    <limit effort="2000" lower="0" upper="0" velocity="0.3"/>
+    <limit effort="2000" lower="0" upper="0" velocity="1.0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -90,7 +90,7 @@
     <parent link="j2n6s200_link_base"/>
     <child link="j2n6s200_link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.3"/>
+    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
     <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -133,7 +133,7 @@
     <parent link="j2n6s200_link_1"/>
     <child link="j2n6s200_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="0.3"/>
+    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="1.0"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -176,7 +176,7 @@
     <parent link="j2n6s200_link_2"/>
     <child link="j2n6s200_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="0.3"/>
+    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="1.0"/>
     <origin rpy="0 3.14159265359 0" xyz="0 -0.410 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -219,7 +219,7 @@
     <parent link="j2n6s200_link_3"/>
     <child link="j2n6s200_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.3"/>
+    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
     <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -262,7 +262,7 @@
     <parent link="j2n6s200_link_4"/>
     <child link="j2n6s200_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.3"/>
+    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
     <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -300,7 +300,7 @@
     <parent link="j2n6s200_link_5"/>
     <child link="j2n6s200_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.3"/>
+    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
     <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>


### PR DESCRIPTION
We do not need this to be 0.3. The bot can take up to 1.0.

These should be hard limits (as soft limits are set in code).