### PR TITLE
Update xacro files and build command for lib updates

### DIFF
--- a/process_xacros.bash
+++ b/process_xacros.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-xacro --inorder -o robots_urdf/ada.urdf robots/j2n6s200_standalone.xacro
-xacro --inorder -o robots_urdf/ada_with_camera.urdf robots/j2n6s200_standalone.xacro with_camera:=true
-xacro --inorder -o robots_urdf/ada_with_forque.urdf robots/j2n6s200_standalone.xacro with_forque:=true
-xacro --inorder -o robots_urdf/ada_with_camera_forque.urdf robots/j2n6s200_standalone.xacro with_camera:=true with_forque:=true
+xacro -o robots_urdf/ada.urdf robots/j2n6s200_standalone.xacro
+xacro -o robots_urdf/ada_with_camera.urdf robots/j2n6s200_standalone.xacro with_camera:=true
+xacro -o robots_urdf/ada_with_forque.urdf robots/j2n6s200_standalone.xacro with_forque:=true
+xacro -o robots_urdf/ada_with_camera_forque.urdf robots/j2n6s200_standalone.xacro with_camera:=true with_forque:=true

--- a/robots/j2n6s200.xacro
+++ b/robots/j2n6s200.xacro
@@ -8,93 +8,93 @@
     <xacro:include filename="$(find ada_description)/robots/kinova_common.xacro" />
     <xacro:include filename="$(find ada_description)/robots/kinova_finger_set.xacro" />
 
-    <property name="link_base_mesh" value="base" />
-    <property name="link_1_mesh" value="shoulder" />
-    <property name="link_2_mesh" value="arm" />
-    <property name="link_3_mesh" value="forearm" />
-    <property name="link_4_mesh" value="wrist" />
-    <property name="link_5_mesh" value="wrist" />
-    <property name="link_6_mesh" value="hand_2finger" />
+    <xacro:property name="link_base_mesh" value="base" />
+    <xacro:property name="link_1_mesh" value="shoulder" />
+    <xacro:property name="link_2_mesh" value="arm" />
+    <xacro:property name="link_3_mesh" value="forearm" />
+    <xacro:property name="link_4_mesh" value="wrist" />
+    <xacro:property name="link_5_mesh" value="wrist" />
+    <xacro:property name="link_6_mesh" value="hand_2finger" />
 
-    <property name="link_base_mesh_no" value="0" />
-    <property name="link_1_mesh_no" value="1" />
-    <property name="link_2_mesh_no" value="2" />
-    <property name="link_3_mesh_no" value="3" />
-    <property name="link_4_mesh_no" value="4" />
-    <property name="link_5_mesh_no" value="4" />
-    <property name="link_6_mesh_no" value="56" />
+    <xacro:property name="link_base_mesh_no" value="0" />
+    <xacro:property name="link_1_mesh_no" value="1" />
+    <xacro:property name="link_2_mesh_no" value="2" />
+    <xacro:property name="link_3_mesh_no" value="3" />
+    <xacro:property name="link_4_mesh_no" value="4" />
+    <xacro:property name="link_5_mesh_no" value="4" />
+    <xacro:property name="link_6_mesh_no" value="56" />
 
-    <property name="joint_base" value="joint_base" />
-    <property name="joint_base_type" value="fixed" />
-    <property name="joint_base_axis_xyz" value="0 0 0" />
-    <property name="joint_base_origin_xyz" value="0 0 0" />
-    <property name="joint_base_origin_rpy" value="0 0 0" />
+    <xacro:property name="joint_base" value="joint_base" />
+    <xacro:property name="joint_base_type" value="fixed" />
+    <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
+    <xacro:property name="joint_base_origin_xyz" value="0 0 0" />
+    <xacro:property name="joint_base_origin_rpy" value="0 0 0" />
 
-    <property name="joint_1" value="joint_1" />
-    <property name="joint_1_type" value="continuous" />
-    <property name="joint_1_axis_xyz" value="0 0 1" />
-    <property name="joint_1_origin_xyz" value="0 0 0.15675" />
-    <property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <property name="joint_1_upper_limit" value="${2*J_PI}" />
+    <xacro:property name="joint_1" value="joint_1" />
+    <xacro:property name="joint_1_type" value="continuous" />
+    <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
+    <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
+    <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
+    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
+    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
 
-    <property name="joint_2" value="joint_2" />
-    <property name="joint_2_type" value="revolute" />
-    <property name="joint_2_axis_xyz" value="0 0 1" />
-    <property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
-    <property name="joint_2_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <property name="joint_2_lower_limit" value="${47/180*J_PI}" />
-    <property name="joint_2_upper_limit" value="${313/180*J_PI}" />
+    <xacro:property name="joint_2" value="joint_2" />
+    <xacro:property name="joint_2_type" value="revolute" />
+    <xacro:property name="joint_2_axis_xyz" value="0 0 1" />
+    <xacro:property name="joint_2_origin_xyz" value="0 0.0016 -0.11875" />
+    <xacro:property name="joint_2_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
+    <xacro:property name="joint_2_lower_limit" value="${47/180*J_PI}" />
+    <xacro:property name="joint_2_upper_limit" value="${313/180*J_PI}" />
 
-    <property name="joint_3" value="joint_3" />
-    <property name="joint_3_type" value="revolute" />
-    <property name="joint_3_axis_xyz" value="0 0 1" />
-    <property name="joint_3_origin_xyz" value="0 -0.410 0" />
-    <property name="joint_3_origin_rpy" value="0 ${J_PI} 0" />
-    <property name="joint_3_lower_limit" value="${19/180*J_PI}" />
-    <property name="joint_3_upper_limit" value="${341/180*J_PI}" />
+    <xacro:property name="joint_3" value="joint_3" />
+    <xacro:property name="joint_3_type" value="revolute" />
+    <xacro:property name="joint_3_axis_xyz" value="0 0 1" />
+    <xacro:property name="joint_3_origin_xyz" value="0 -0.410 0" />
+    <xacro:property name="joint_3_origin_rpy" value="0 ${J_PI} 0" />
+    <xacro:property name="joint_3_lower_limit" value="${19/180*J_PI}" />
+    <xacro:property name="joint_3_upper_limit" value="${341/180*J_PI}" />
 
-    <property name="joint_4" value="joint_4" />
-    <property name="joint_4_type" value="continuous" />
-    <property name="joint_4_axis_xyz" value="0 0 1" />
-    <property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
-    <property name="joint_4_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <property name="joint_4_lower_limit" value="${-2*J_PI}" />
-    <property name="joint_4_upper_limit" value="${2*J_PI}" />
+    <xacro:property name="joint_4" value="joint_4" />
+    <xacro:property name="joint_4_type" value="continuous" />
+    <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
+    <xacro:property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
+    <xacro:property name="joint_4_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
+    <xacro:property name="joint_4_lower_limit" value="${-2*J_PI}" />
+    <xacro:property name="joint_4_upper_limit" value="${2*J_PI}" />
 
-    <property name="joint_5" value="joint_5" />
-    <property name="joint_5_type" value="continuous" />
-    <property name="joint_5_axis_xyz" value="0 0 1" />
-    <property name="joint_5_origin_xyz" value="0 -0.03703 -0.06414" />
-    <property name="joint_5_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <property name="joint_5_lower_limit" value="${-2*J_PI}" />
-    <property name="joint_5_upper_limit" value="${2*J_PI}" />
+    <xacro:property name="joint_5" value="joint_5" />
+    <xacro:property name="joint_5_type" value="continuous" />
+    <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
+    <xacro:property name="joint_5_origin_xyz" value="0 -0.03703 -0.06414" />
+    <xacro:property name="joint_5_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
+    <xacro:property name="joint_5_lower_limit" value="${-2*J_PI}" />
+    <xacro:property name="joint_5_upper_limit" value="${2*J_PI}" />
 
-    <property name="joint_6" value="joint_6" />
-    <property name="joint_6_type" value="continuous" />
-    <property name="joint_6_axis_xyz" value="0 0 1" />
-    <property name="joint_6_origin_xyz" value="0 -0.03703 -0.06414" />
-    <property name="joint_6_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <property name="joint_6_lower_limit" value="${-2*J_PI}" />
-    <property name="joint_6_upper_limit" value="${2*J_PI}" />
+    <xacro:property name="joint_6" value="joint_6" />
+    <xacro:property name="joint_6_type" value="continuous" />
+    <xacro:property name="joint_6_axis_xyz" value="0 0 1" />
+    <xacro:property name="joint_6_origin_xyz" value="0 -0.03703 -0.06414" />
+    <xacro:property name="joint_6_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
+    <xacro:property name="joint_6_lower_limit" value="${-2*J_PI}" />
+    <xacro:property name="joint_6_upper_limit" value="${2*J_PI}" />
 
-    <property name="joint_end_effector" value="end_effector_offset" />
-    <property name="joint_end_effector_type" value="fixed" />
-    <property name="joint_end_effector_axis_xyz" value="0 0 0" />
-    <property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
-    <property name="joint_end_effector_origin_rpy" value="${J_PI} 0 0" />
+    <xacro:property name="joint_end_effector" value="end_effector_offset" />
+    <xacro:property name="joint_end_effector_type" value="fixed" />
+    <xacro:property name="joint_end_effector_axis_xyz" value="0 0 0" />
+    <xacro:property name="joint_end_effector_origin_xyz" value="0 0 -0.1600" />
+    <xacro:property name="joint_end_effector_origin_rpy" value="${J_PI} 0 0" />
 
-    <property name="joint_hand_tip" value="end_effector_offset" />
-    <property name="joint_hand_tip_type" value="fixed" />
-    <property name="joint_hand_tip_axis_xyz" value="0 0 0" />
-    <property name="joint_hand_tip_origin_xyz" value="0 0 0.0370" />
-    <property name="joint_hand_tip_origin_rpy" value="0 0 0" />
+    <xacro:property name="joint_hand_tip" value="end_effector_offset" />
+    <xacro:property name="joint_hand_tip_type" value="fixed" />
+    <xacro:property name="joint_hand_tip_axis_xyz" value="0 0 0" />
+    <xacro:property name="joint_hand_tip_origin_xyz" value="0 0 0.0370" />
+    <xacro:property name="joint_hand_tip_origin_rpy" value="0 0 0" />
 
-    <property name="joint_hand_base" value="hand_base" />
-    <property name="joint_hand_base_type" value="fixed" />
-    <property name="joint_hand_base_axis_xyz" value="0 0 0" />
-    <property name="joint_hand_base_origin_xyz" value="0 0 0" />
-    <property name="joint_hand_base_origin_rpy" value="0 0 0" />
+    <xacro:property name="joint_hand_base" value="hand_base" />
+    <xacro:property name="joint_hand_base_type" value="fixed" />
+    <xacro:property name="joint_hand_base_axis_xyz" value="0 0 0" />
+    <xacro:property name="joint_hand_base_origin_xyz" value="0 0 0" />
+    <xacro:property name="joint_hand_base_origin_rpy" value="0 0 0" />
 
 
     <xacro:macro name="j2n6s200" params="base_parent hide_final_ring:=false prefix:=j2n6s200">

--- a/robots/j2n6s200_standalone.xacro
+++ b/robots/j2n6s200_standalone.xacro
@@ -14,8 +14,8 @@
   <xacro:arg name="with_forque" default="false" />
 
   <link name="world"/>
-  <property name="robot_root" value="world" />
-  <property name="prefix" value="j2n6s200" />
+  <xacro:property name="robot_root" value="world" />
+  <xacro:property name="prefix" value="j2n6s200" />
 
   <xacro:j2n6s200  base_parent="${robot_root}" hide_final_ring="$(arg with_camera)"/>
   <!--xacro:j2n6s200  base_parent="${robot_root}" /-->

--- a/robots/kinova_common.xacro
+++ b/robots/kinova_common.xacro
@@ -7,7 +7,7 @@
 <xacro:include filename="$(find ada_description)/robots/kinova_inertial.xacro" />
 
 
-    <property name="J_PI" value="3.1415926535897931" />
+    <xacro:property name="J_PI" value="3.1415926535897931" />
 
     <xacro:macro name="kinova_armlink" params="link_name link_mesh ring_mesh:=ring_big use_ring_mesh:=false mesh_no">
         <link name="${link_name}">


### PR DESCRIPTION
1. Changes `<property>` to `<xacro:property>`. Maybe this used to work, but the current form doesn't build.
2. Removes the `--inorder` flag, xacro is complaining about this, it was made a default since Jade, which is 6 years old now

This PR is required for a downstream change I have.