### PR TITLE
Update xacro macros and re-run urdf generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ada_description [![Build Status](https://travis-ci.com/personalrobotics/ada_description.svg?token=1MmAniN9fkMcwpRUTdFq&branch=master)](https://travis-ci.com/personalrobotics/ada_description)
 urdf files for ADA
+
+## Making changes
+
+Do not make edits to `.urdf` files in `/robots_urdf` directly if you want to keep your changes persisted. Instead:
+
+- Make changes to `.xacro` files in the `/robots` directory
+- Run `./process_xacros.bash`

--- a/robots/camera.xacro
+++ b/robots/camera.xacro
@@ -19,9 +19,9 @@
         </material>
       </visual>
       <collision>
-        <origin  rpy="0 0 0" xyz="-0.014 -0.062 -0.023"  />
+        <origin rpy="0 0 0" xyz="-0.008 -0.055 0.01"/>
         <geometry>
-          <mesh filename="package://ada_description/meshes/collision_camera_joule.dae" scale="0.001 0.001 0.00098"/>
+          <mesh filename="package://ada_description/meshes/collision_camera_joule.dae" scale="0.0008 0.00076 0.0006"/>
         </geometry>
       </collision>
     </link>

--- a/robots/kinova_common.xacro
+++ b/robots/kinova_common.xacro
@@ -42,12 +42,12 @@
 
     </xacro:macro>
 
-  <xacro:macro name="kinova_armjoint" params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit fixed:=false">
+  <xacro:macro name="kinova_armjoint" params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit joint_velocity_limit=1.0 fixed:=false">
     <joint name="${joint_name}" type="${type}">
         <parent link="${parent}"/>
         <child link="${child}"/>
         <axis xyz="${joint_axis_xyz}"/>
-        <limit effort="2000" velocity="0.8" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
+        <limit effort="2000" velocity="${joint_velocity_limit}" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
         <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
         <dynamics damping="0.0" friction="0.0"/>
      </joint>

--- a/robots_urdf/ada.urdf
+++ b/robots_urdf/ada.urdf
@@ -4,7 +4,7 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <!-- j2n6s200 refers to jaco v2 6DOF non-spherical 2fingers -->
-<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- links      		mesh_no
    base           		0
    shoulder       		1
@@ -50,14 +50,14 @@
     <inertial>
       <mass value="0.46784"/>
       <origin rpy="0 0 0" xyz="0 0 0.1255"/>
-      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.000374272"/>
+      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.00037427200000000004"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_base" type="fixed">
     <parent link="world"/>
     <child link="j2n6s200_link_base"/>
     <axis xyz="0 0 0"/>
-    <limit effort="2000" lower="0" upper="0" velocity="0.8"/>
+    <limit effort="2000" lower="0" upper="0" velocity="1.0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -83,15 +83,15 @@
     <inertial>
       <mass value="0.7477"/>
       <origin xyz="0 -0.002 -0.0605"/>
-      <inertia ixx="0.00152031725204" ixy="0" ixz="0" iyy="0.00152031725204" iyz="0" izz="0.00059816"/>
+      <inertia ixx="0.0015203172520400004" ixy="0" ixz="0" iyy="0.0015203172520400004" iyz="0" izz="0.00059816"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_1" type="continuous">
     <parent link="j2n6s200_link_base"/>
     <child link="j2n6s200_link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_1_trans">
@@ -126,15 +126,15 @@
     <inertial>
       <mass value="0.99"/>
       <origin xyz="0 -0.2065 -0.01"/>
-      <inertia ixx="0.010502207991" ixy="0" ixz="0" iyy="0.000792" iyz="0" izz="0.010502207991"/>
+      <inertia ixx="0.010502207990999999" ixy="0" ixz="0" iyy="0.0007920000000000001" iyz="0" izz="0.010502207990999999"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_2" type="revolute">
     <parent link="j2n6s200_link_1"/>
     <child link="j2n6s200_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="0.8"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
+    <limit effort="2000" lower="0.8203047484373349" upper="5.462880558742252" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_2_trans">
@@ -169,15 +169,15 @@
     <inertial>
       <mass value="0.6763"/>
       <origin xyz="0 0.081 -0.0086"/>
-      <inertia ixx="0.00142022431908" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.00142022431908"/>
+      <inertia ixx="0.0014202243190800001" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.0014202243190800001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_3" type="revolute">
     <parent link="j2n6s200_link_2"/>
     <child link="j2n6s200_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="0.8"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 -0.410 0"/>
+    <limit effort="2000" lower="0.33161255787892263" upper="5.951572749300664" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 -0.410 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_3_trans">
@@ -212,15 +212,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_4" type="continuous">
     <parent link="j2n6s200_link_3"/>
     <child link="j2n6s200_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_4_trans">
@@ -255,15 +255,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_5" type="continuous">
     <parent link="j2n6s200_link_4"/>
     <child link="j2n6s200_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_5_trans">
@@ -285,11 +285,6 @@
         <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
       </material>
     </visual>
-    <visual>
-      <geometry>
-        <mesh filename="package://ada_description/meshes/ring_small.dae"/>
-      </geometry>
-    </visual>
     <collision>
       <geometry>
         <mesh filename="package://ada_description/meshes/collision_hand_2finger.dae"/>
@@ -298,15 +293,15 @@
     <inertial>
       <mass value="0.78"/>
       <origin xyz="0 0 -0.06"/>
-      <inertia ixx="0.000370498518" ixy="0" ixz="0" iyy="0.000370498518" iyz="0" izz="0.000624"/>
+      <inertia ixx="0.00037049851799999997" ixy="0" ixz="0" iyy="0.00037049851799999997" iyz="0" izz="0.0006240000000000001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_6" type="continuous">
     <parent link="j2n6s200_link_5"/>
     <child link="j2n6s200_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_6_trans">
@@ -326,7 +321,7 @@
     <child link="j2n6s200_end_effector"/>
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
-    <origin rpy="3.14159265359 0 0" xyz="0 0 -0.1600"/>
+    <origin rpy="3.141592653589793 0 0" xyz="0 0 -0.1600"/>
   </joint>
   <link name="j2n6s200_hand_tip">
   </link>

--- a/robots_urdf/ada_with_camera.urdf
+++ b/robots_urdf/ada_with_camera.urdf
@@ -4,7 +4,7 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <!-- j2n6s200 refers to jaco v2 6DOF non-spherical 2fingers -->
-<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- links      		mesh_no
    base           		0
    shoulder       		1
@@ -50,14 +50,14 @@
     <inertial>
       <mass value="0.46784"/>
       <origin rpy="0 0 0" xyz="0 0 0.1255"/>
-      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.000374272"/>
+      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.00037427200000000004"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_base" type="fixed">
     <parent link="world"/>
     <child link="j2n6s200_link_base"/>
     <axis xyz="0 0 0"/>
-    <limit effort="2000" lower="0" upper="0" velocity="0.8"/>
+    <limit effort="2000" lower="0" upper="0" velocity="1.0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -83,15 +83,15 @@
     <inertial>
       <mass value="0.7477"/>
       <origin xyz="0 -0.002 -0.0605"/>
-      <inertia ixx="0.00152031725204" ixy="0" ixz="0" iyy="0.00152031725204" iyz="0" izz="0.00059816"/>
+      <inertia ixx="0.0015203172520400004" ixy="0" ixz="0" iyy="0.0015203172520400004" iyz="0" izz="0.00059816"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_1" type="continuous">
     <parent link="j2n6s200_link_base"/>
     <child link="j2n6s200_link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_1_trans">
@@ -126,15 +126,15 @@
     <inertial>
       <mass value="0.99"/>
       <origin xyz="0 -0.2065 -0.01"/>
-      <inertia ixx="0.010502207991" ixy="0" ixz="0" iyy="0.000792" iyz="0" izz="0.010502207991"/>
+      <inertia ixx="0.010502207990999999" ixy="0" ixz="0" iyy="0.0007920000000000001" iyz="0" izz="0.010502207990999999"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_2" type="revolute">
     <parent link="j2n6s200_link_1"/>
     <child link="j2n6s200_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="0.8"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
+    <limit effort="2000" lower="0.8203047484373349" upper="5.462880558742252" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_2_trans">
@@ -169,15 +169,15 @@
     <inertial>
       <mass value="0.6763"/>
       <origin xyz="0 0.081 -0.0086"/>
-      <inertia ixx="0.00142022431908" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.00142022431908"/>
+      <inertia ixx="0.0014202243190800001" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.0014202243190800001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_3" type="revolute">
     <parent link="j2n6s200_link_2"/>
     <child link="j2n6s200_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="0.8"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 -0.410 0"/>
+    <limit effort="2000" lower="0.33161255787892263" upper="5.951572749300664" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 -0.410 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_3_trans">
@@ -212,15 +212,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_4" type="continuous">
     <parent link="j2n6s200_link_3"/>
     <child link="j2n6s200_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_4_trans">
@@ -255,15 +255,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_5" type="continuous">
     <parent link="j2n6s200_link_4"/>
     <child link="j2n6s200_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_5_trans">
@@ -293,15 +293,15 @@
     <inertial>
       <mass value="0.78"/>
       <origin xyz="0 0 -0.06"/>
-      <inertia ixx="0.000370498518" ixy="0" ixz="0" iyy="0.000370498518" iyz="0" izz="0.000624"/>
+      <inertia ixx="0.00037049851799999997" ixy="0" ixz="0" iyy="0.00037049851799999997" iyz="0" izz="0.0006240000000000001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_6" type="continuous">
     <parent link="j2n6s200_link_5"/>
     <child link="j2n6s200_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_6_trans">
@@ -321,7 +321,7 @@
     <child link="j2n6s200_end_effector"/>
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
-    <origin rpy="3.14159265359 0 0" xyz="0 0 -0.1600"/>
+    <origin rpy="3.141592653589793 0 0" xyz="0 0 -0.1600"/>
   </joint>
   <link name="j2n6s200_hand_tip">
   </link>
@@ -482,9 +482,9 @@
       </material>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.014 -0.062 -0.023"/>
+      <origin rpy="0 0 0" xyz="-0.008 -0.055 0.01"/>
       <geometry>
-        <mesh filename="package://ada_description/meshes/collision_camera_joule.dae" scale="0.001 0.001 0.00098"/>
+        <mesh filename="package://ada_description/meshes/collision_camera_joule.dae" scale="0.0008 0.00076 0.0006"/>
       </geometry>
     </collision>
   </link>

--- a/robots_urdf/ada_with_camera_forque.urdf
+++ b/robots_urdf/ada_with_camera_forque.urdf
@@ -4,7 +4,7 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <!-- j2n6s200 refers to jaco v2 6DOF non-spherical 2fingers -->
-<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- links      		mesh_no
    base           		0
    shoulder       		1
@@ -50,7 +50,7 @@
     <inertial>
       <mass value="0.46784"/>
       <origin rpy="0 0 0" xyz="0 0 0.1255"/>
-      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.000374272"/>
+      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.00037427200000000004"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_base" type="fixed">
@@ -83,15 +83,15 @@
     <inertial>
       <mass value="0.7477"/>
       <origin xyz="0 -0.002 -0.0605"/>
-      <inertia ixx="0.00152031725204" ixy="0" ixz="0" iyy="0.00152031725204" iyz="0" izz="0.00059816"/>
+      <inertia ixx="0.0015203172520400004" ixy="0" ixz="0" iyy="0.0015203172520400004" iyz="0" izz="0.00059816"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_1" type="continuous">
     <parent link="j2n6s200_link_base"/>
     <child link="j2n6s200_link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_1_trans">
@@ -126,15 +126,15 @@
     <inertial>
       <mass value="0.99"/>
       <origin xyz="0 -0.2065 -0.01"/>
-      <inertia ixx="0.010502207991" ixy="0" ixz="0" iyy="0.000792" iyz="0" izz="0.010502207991"/>
+      <inertia ixx="0.010502207990999999" ixy="0" ixz="0" iyy="0.0007920000000000001" iyz="0" izz="0.010502207990999999"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_2" type="revolute">
     <parent link="j2n6s200_link_1"/>
     <child link="j2n6s200_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="1.0"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
+    <limit effort="2000" lower="0.8203047484373349" upper="5.462880558742252" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_2_trans">
@@ -169,15 +169,15 @@
     <inertial>
       <mass value="0.6763"/>
       <origin xyz="0 0.081 -0.0086"/>
-      <inertia ixx="0.00142022431908" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.00142022431908"/>
+      <inertia ixx="0.0014202243190800001" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.0014202243190800001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_3" type="revolute">
     <parent link="j2n6s200_link_2"/>
     <child link="j2n6s200_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="1.0"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 -0.410 0"/>
+    <limit effort="2000" lower="0.33161255787892263" upper="5.951572749300664" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 -0.410 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_3_trans">
@@ -212,15 +212,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_4" type="continuous">
     <parent link="j2n6s200_link_3"/>
     <child link="j2n6s200_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_4_trans">
@@ -255,15 +255,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_5" type="continuous">
     <parent link="j2n6s200_link_4"/>
     <child link="j2n6s200_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_5_trans">
@@ -293,15 +293,15 @@
     <inertial>
       <mass value="0.78"/>
       <origin xyz="0 0 -0.06"/>
-      <inertia ixx="0.000370498518" ixy="0" ixz="0" iyy="0.000370498518" iyz="0" izz="0.000624"/>
+      <inertia ixx="0.00037049851799999997" ixy="0" ixz="0" iyy="0.00037049851799999997" iyz="0" izz="0.0006240000000000001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_6" type="continuous">
     <parent link="j2n6s200_link_5"/>
     <child link="j2n6s200_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="1.0"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_6_trans">
@@ -321,7 +321,7 @@
     <child link="j2n6s200_end_effector"/>
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
-    <origin rpy="3.14159265359 0 0" xyz="0 0 -0.1600"/>
+    <origin rpy="3.141592653589793 0 0" xyz="0 0 -0.1600"/>
   </joint>
   <link name="j2n6s200_hand_tip">
   </link>
@@ -475,6 +475,7 @@
       <origin rpy="0 0 0" xyz="-0.014 -0.062 -0.023"/>
       <geometry>
         <mesh filename="package://ada_description/meshes/camera_joule.dae" scale="0.001 0.001 0.001"/>
+        <!-- <mesh filename="package://ada_description/meshes/collision_camera_joule.dae" scale="0.001 0.001 0.00098"/> -->
       </geometry>
       <material name="carbon_fiber">
         <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>

--- a/robots_urdf/ada_with_forque.urdf
+++ b/robots_urdf/ada_with_forque.urdf
@@ -4,7 +4,7 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <!-- j2n6s200 refers to jaco v2 6DOF non-spherical 2fingers -->
-<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="j2n6s200" xmlns:body="http://playerstage.sourceforge.net/gazebo/xmlschema/#body" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:gazebo="http://playerstage.sourceforge.net/gazebo/xmlschema/#gz" xmlns:geom="http://playerstage.sourceforge.net/gazebo/xmlschema/#geom" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#joint" xmlns:model="http://playerstage.sourceforge.net/gazebo/xmlschema/#model" xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics" xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable" xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- links      		mesh_no
    base           		0
    shoulder       		1
@@ -50,14 +50,14 @@
     <inertial>
       <mass value="0.46784"/>
       <origin rpy="0 0 0" xyz="0 0 0.1255"/>
-      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.000374272"/>
+      <inertia ixx="0.000951270861568" ixy="0" ixz="0" iyy="0.000951270861568" iyz="0" izz="0.00037427200000000004"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_base" type="fixed">
     <parent link="world"/>
     <child link="j2n6s200_link_base"/>
     <axis xyz="0 0 0"/>
-    <limit effort="2000" lower="0" upper="0" velocity="0.8"/>
+    <limit effort="2000" lower="0" upper="0" velocity="1.0"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
@@ -83,15 +83,15 @@
     <inertial>
       <mass value="0.7477"/>
       <origin xyz="0 -0.002 -0.0605"/>
-      <inertia ixx="0.00152031725204" ixy="0" ixz="0" iyy="0.00152031725204" iyz="0" izz="0.00059816"/>
+      <inertia ixx="0.0015203172520400004" ixy="0" ixz="0" iyy="0.0015203172520400004" iyz="0" izz="0.00059816"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_1" type="continuous">
     <parent link="j2n6s200_link_base"/>
     <child link="j2n6s200_link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 0 0.15675"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 0 0.15675"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_1_trans">
@@ -126,15 +126,15 @@
     <inertial>
       <mass value="0.99"/>
       <origin xyz="0 -0.2065 -0.01"/>
-      <inertia ixx="0.010502207991" ixy="0" ixz="0" iyy="0.000792" iyz="0" izz="0.010502207991"/>
+      <inertia ixx="0.010502207990999999" ixy="0" ixz="0" iyy="0.0007920000000000001" iyz="0" izz="0.010502207990999999"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_2" type="revolute">
     <parent link="j2n6s200_link_1"/>
     <child link="j2n6s200_link_2"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.820304748437" upper="5.46288055874" velocity="0.8"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.0016 -0.11875"/>
+    <limit effort="2000" lower="0.8203047484373349" upper="5.462880558742252" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.0016 -0.11875"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_2_trans">
@@ -169,15 +169,15 @@
     <inertial>
       <mass value="0.6763"/>
       <origin xyz="0 0.081 -0.0086"/>
-      <inertia ixx="0.00142022431908" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.00142022431908"/>
+      <inertia ixx="0.0014202243190800001" ixy="0" ixz="0" iyy="0.000304335" iyz="0" izz="0.0014202243190800001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_3" type="revolute">
     <parent link="j2n6s200_link_2"/>
     <child link="j2n6s200_link_3"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0.331612557879" upper="5.9515727493" velocity="0.8"/>
-    <origin rpy="0 3.14159265359 0" xyz="0 -0.410 0"/>
+    <limit effort="2000" lower="0.33161255787892263" upper="5.951572749300664" velocity="1.0"/>
+    <origin rpy="0 3.141592653589793 0" xyz="0 -0.410 0"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_3_trans">
@@ -212,15 +212,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_4" type="continuous">
     <parent link="j2n6s200_link_3"/>
     <child link="j2n6s200_link_4"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="-1.57079632679 0 3.14159265359" xyz="0 0.2073 -0.0114"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="-1.5707963267948966 0 3.141592653589793" xyz="0 0.2073 -0.0114"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_4_trans">
@@ -255,15 +255,15 @@
     <inertial>
       <mass value="0.1785"/>
       <origin xyz="0 -0.037 -0.0642"/>
-      <inertia ixx="7.73496906e-05" ixy="0" ixz="0" iyy="7.73496906e-05" iyz="0" izz="0.0001428"/>
+      <inertia ixx="7.734969059999999e-05" ixy="0" ixz="0" iyy="7.734969059999999e-05" iyz="0" izz="0.0001428"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_5" type="continuous">
     <parent link="j2n6s200_link_4"/>
     <child link="j2n6s200_link_5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_5_trans">
@@ -285,11 +285,6 @@
         <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
       </material>
     </visual>
-    <visual>
-      <geometry>
-        <mesh filename="package://ada_description/meshes/ring_small.dae"/>
-      </geometry>
-    </visual>
     <collision>
       <geometry>
         <mesh filename="package://ada_description/meshes/collision_hand_2finger.dae"/>
@@ -298,15 +293,15 @@
     <inertial>
       <mass value="0.78"/>
       <origin xyz="0 0 -0.06"/>
-      <inertia ixx="0.000370498518" ixy="0" ixz="0" iyy="0.000370498518" iyz="0" izz="0.000624"/>
+      <inertia ixx="0.00037049851799999997" ixy="0" ixz="0" iyy="0.00037049851799999997" iyz="0" izz="0.0006240000000000001"/>
     </inertial>
   </link>
   <joint name="j2n6s200_joint_6" type="continuous">
     <parent link="j2n6s200_link_5"/>
     <child link="j2n6s200_link_6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="-6.28318530718" upper="6.28318530718" velocity="0.8"/>
-    <origin rpy="1.0471975512 0 3.14159265359" xyz="0 -0.03703 -0.06414"/>
+    <limit effort="2000" lower="-6.283185307179586" upper="6.283185307179586" velocity="1.0"/>
+    <origin rpy="1.0471975511965976 0 3.141592653589793" xyz="0 -0.03703 -0.06414"/>
     <dynamics damping="0.0" friction="0.0"/>
   </joint>
   <transmission name="j2n6s200_joint_6_trans">
@@ -326,7 +321,7 @@
     <child link="j2n6s200_end_effector"/>
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
-    <origin rpy="3.14159265359 0 0" xyz="0 0 -0.1600"/>
+    <origin rpy="3.141592653589793 0 0" xyz="0 0 -0.1600"/>
   </joint>
   <link name="j2n6s200_hand_tip">
   </link>


### PR DESCRIPTION
Probably due to xacro bugs being around, urdfs were being manually edited for a long time. This PR updates the xacro macros to match manual edits that were being made to `ada_with_camera_forque.urdf` and commits the output of a fresh `./process_xacros.bash` run. This makes it easier to keep all the urdfs in sync and for me to reuse configuration for simulation modeling.

The actual changes to urdfs are basically no-ops, if you look at the diff for `robots_urdf/ada_with_camera_forque.urdf` you'll see that only sig figs were changed. Some of the other urdfs have velocity changes because those now reflect the manual edits made to `robots_urdf/ada_with_camera_forque.urdf`