### PR TITLE
Revert "Merge pull request #28 from personalrobotics/egordon/forque_tip_fix"

### DIFF
--- a/ada_description/robots_urdf/ada_with_camera_forque.urdf
+++ b/ada_description/robots_urdf/ada_with_camera_forque.urdf
@@ -525,7 +525,7 @@
     <child link="j2n6s200_forque_end_effector"/>
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
-    <origin rpy="3.1415 0 1.57075" xyz="0.002 0.005 -0.093"/>
+    <origin rpy="3.1415 0 1.57075" xyz="0.007 0 -0.093"/>
   </joint>
   <link name="j2n6s200_forque_tip">
   </link>
@@ -535,6 +535,6 @@
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
     <!-- Rotation consistent with pointers of forque: -->
-    <origin rpy="2.6415 0 1.57075" xyz="0.002 0.005 -0.093"/>
+    <origin rpy="2.6415 0 1.57075" xyz="0.007 0 -0.093"/>
   </joint>
 </robot>

--- a/ada_description/robots_urdf/ada_with_forque.urdf
+++ b/ada_description/robots_urdf/ada_with_forque.urdf
@@ -499,7 +499,7 @@
     <child link="j2n6s200_forque_end_effector"/>
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
-    <origin rpy="3.1415 0 1.57075" xyz="0.002 0.005 -0.093"/>
+    <origin rpy="3.1415 0 1.57075" xyz="0.007 0 -0.093"/>
   </joint>
   <link name="j2n6s200_forque_tip">
   </link>
@@ -509,6 +509,6 @@
     <axis xyz="0 0 0"/>
     <limit effort="2000" lower="0" upper="0" velocity="1"/>
     <!-- Rotation consistent with pointers of forque: -->
-    <origin rpy="2.6415 0 1.57075" xyz="0.002 0.005 -0.093"/>
+    <origin rpy="2.6415 0 1.57075" xyz="0.007 0 -0.093"/>
   </joint>
 </robot>


### PR DESCRIPTION
The core issue that the "fix" was addressing was a camera calibration issue, not a bent fork issue. Now that the camera calibration has been fixed, this change is no longer necessary/desirable.

This reverts commit 607e0925aebdd0729e7a9cf9d5535487759f52b5, reversing changes made to f649c4e3298c2e6339e71454b2f586efe0835c49.